### PR TITLE
Replace `any` default type for generics with `unknown`

### DIFF
--- a/test/types/circular.ts
+++ b/test/types/circular.ts
@@ -1,6 +1,6 @@
 import {Circular} from '../..';
 
-const circular = new Circular();
+const circular = new Circular<string>();
 
 // Append a node holding the value `E`
 circular.append('E');
@@ -57,9 +57,9 @@ circular.reverse().map(x => `[${x}]`).join('->');
 // Clear the list
 circular.clear(); // => Circular { head: null, length: 0, last: null }
 
-// Reduce values to a final sum
-circular.append(5, 10, 15, 20, 25).reduce((x, y) => x + y, 0);
-//=> 75
+// Concatenate letters using reduce
+circular.append('A', 'B', 'C', 'D', 'E').reduce((x, y) => x + y, '');
+//=> ABCDE
 
 circular.append('R', 'O', 'G');
 circular.includes('G'); //=> true

--- a/test/types/linear.ts
+++ b/test/types/linear.ts
@@ -1,6 +1,6 @@
 import {Linear} from '../..';
 
-const linear = new Linear();
+const linear = new Linear<string>();
 
 // Append a node holding the value `E`
 linear.append('E');
@@ -51,9 +51,9 @@ linear.reverse().map(x => `[${x}]`).join('->');
 // Clear the list
 linear.clear(); // => Linear { head: null, length: 0, last: null }
 
-// Reduce values to a final sum
-linear.append(5, 10, 15, 20, 25).reduce((x, y) => x + y, 0);
-//=> 75
+// Concatenate letters using reduce
+linear.append('A', 'B', 'C', 'D', 'E').reduce((x, y) => x + y, '');
+//=> ABCDE
 
 linear.append('R', 'O', 'G');
 linear.includes('G'); //=> true

--- a/types/doublie.d.ts
+++ b/types/doublie.d.ts
@@ -1,9 +1,9 @@
 declare namespace node {
   export interface Constructor {
-    new <T = any>(value?: T): Instance<T>;
+    new <T = unknown>(value?: T): Instance<T>;
   }
 
-  export interface Instance<T = any> {
+  export interface Instance<T = unknown> {
     value: T;
     next: Instance<T> | null;
     prev: Instance<T> | null;
@@ -49,10 +49,10 @@ declare namespace linear {
   }
 
   export interface Constructor {
-    new <T = any>(): Instance<T>;
+    new <T = unknown>(): Instance<T>;
   }
 
-  interface Instance<T = any> extends list.Instance<T> {
+  interface Instance<T = unknown> extends list.Instance<T> {
     readonly head: HeadNode<T> | null;
     readonly last: LastNode<T> | null;
     map<U>(fn: (value: T) => U): Instance<U>;
@@ -72,10 +72,10 @@ declare namespace circular {
   }
 
   export interface Constructor {
-    new <T = any>(): Instance<T>;
+    new <T = unknown>(): Instance<T>;
   }
 
-  interface Instance<T = any> extends list.Instance<T> {
+  interface Instance<T = unknown> extends list.Instance<T> {
     readonly head: HeadNode<T> | null;
     readonly last: LastNode<T> | null;
     map<U>(fn: (value: T) => U): Instance<U>;
@@ -84,9 +84,9 @@ declare namespace circular {
 }
 
 declare namespace doublie {
-  export interface Circular<T = any> extends circular.Instance<T> {}
-  export interface Linear<T = any> extends linear.Instance<T> {}
-  export interface Node<T = any> extends node.Instance<T> {}
+  export interface Circular<T = unknown> extends circular.Instance<T> {}
+  export interface Linear<T = unknown> extends linear.Instance<T> {}
+  export interface Node<T = unknown> extends node.Instance<T> {}
 }
 
 declare const doublie: {


### PR DESCRIPTION
## Description
The PR replaces the any type used as the default type for the generic type parameters with the more type-safe [unknown](https://devblogs.microsoft.com/typescript/announcing-typescript-3-0-rc-2/#the-unknown-type) type.